### PR TITLE
Catch department code between parentheses

### DIFF
--- a/geoconvert/address.py
+++ b/geoconvert/address.py
@@ -45,7 +45,10 @@ class AddressParser(object):
         # Use \b before group because of words like "Publics", "Blancs"
         re.compile(r'\b(B\.?P\.?|C\.?S\.?|CEDEX)\s*\d*', flags=re.I | re.U),
     ]
-    zipcode_re = re.compile(r'(?P<zipcode>(?<!\d)(\d{2}\s*?\d{2,3}|\d{5})(?!\d))')
+    zipcode_re = re.compile(
+        r'(?P<zipcode>(?<!\d)(\d{2}\s*?\d{2,3}|\d{5})(?!\d))'  # Full zipcode
+    )
+    dept_code_re = re.compile(r'\((?P<zipcode>\d{2,3})\)')  # Only dept code
 
     def _clean_address(self, address):
         """
@@ -59,11 +62,17 @@ class AddressParser(object):
         """
         Tries to extract zipcode from address
         """
+        # Catch a full zipcode first.
         match_list = list(self.zipcode_re.finditer(address))
-
-        # It's easier to parse zipcode from the end of the string
+        # It's easier to parse zipcode from the end of the string.
         if match_list:
             return match_list[-1].group('zipcode').replace(' ', '').zfill(5)
+
+        # Catch only dept code second.
+        match_list = list(self.dept_code_re.finditer(address))
+        if match_list:
+            # The zipcode is filled with zeros on the right.
+            return match_list[-1].group('zipcode').ljust(5, "0")
 
     def get_address_class(self):
         """

--- a/test_geoconvert.py
+++ b/test_geoconvert.py
@@ -14,6 +14,7 @@ from geoconvert.convert import capital_name_to_country_id
 from geoconvert.address import AddressParser
 from geoconvert.utils import reverse_dict
 
+
 class GeoconvertTestCase(unittest.TestCase):
     def test_zipcode_to_dept_name(self):
         self.assertEqual(zipcode_to_dept_name('121'), None)
@@ -301,7 +302,11 @@ class AddressParserTestCase(unittest.TestCase):
             (u"M. le Directeur, Paris Bâtiment 153 93352 Paris", '93352', '93'),
             (u"M. le Directeur, Paris Bâtiment 53 93352 Paris", '93352', '93'),
             (u"M. le Directeur, Paris Bâtiment 3 93352 Paris", '93352', '93'),
-            (u"Adresse : CS 72055 56002 Vannes", '56002', '56')
+            (u"Adresse : CS 72055 56002 Vannes", '56002', '56'),
+            (u"Orléans (45)", "45000", "45"),
+            (u"Orléans (45000)", "45000", "45"),
+            (u"Bourg-en-Bresse (01)", "01000", "01"),
+            (u"Bourg-en-Bresse (1)", None, None),
         ]
 
     def test_zipcode(self):


### PR DESCRIPTION
Handle the case where the department code is between parentheses.
In this case, the zipcode is obtained by filling zeros on the right (even though this is only valid for French prefectures).
I added tests (inlcuding a negative one, when only 1 digit is found between parentheses).

By the way, I prefer [parametrized tests](http://doc.pytest.org/en/latest/parametrize.html#parametrize-basics) over one test with for loops testing many cases. You no longer have to figure out which set of input parameters made the test fail, since each set of input parameters count as one test. It is not difficult to change that, and I am willing to do it if it is deemed relevant.