### PR TITLE
south sudan in de and es

### DIFF
--- a/geoconvert/data/countries.py
+++ b/geoconvert/data/countries.py
@@ -17,7 +17,10 @@ special_countries = {
     "republik kongo": "CG",  # de
     "republica do congo": "CG",  # pt
     "congo": "CG",  # en, fr
+    # make sure we never mistake it for SD
     "south sudan": "SS",  # en
+    "sudsudan": "SS", # de
+    "sudan del sur": "SS", # es
 }
 
 
@@ -734,7 +737,6 @@ countries_de = {
         "st vincent und die grenadinen": "VC",
         "sudan": "SD",
         "sudafrika": "ZA",
-        "sudsudan": "SS",
         "suriname": "SR",
         "swasiland": "SZ",
         "syrien": "SY",
@@ -1247,7 +1249,6 @@ countries_es = {
         "sri lanka": "LK",
         "esuatini": "SZ",
         "sudan": "SD",
-        "sudan del sur": "SS",
         "suecia": "SE",
         "suiza": "CH",
         "surinam": "SR",

--- a/test_geoconvert.py
+++ b/test_geoconvert.py
@@ -774,7 +774,7 @@ United States""",
             ("1196 Voie Camillien-Houde, Montréal, QC H3H 1A1, Canada", "CA"),
             ("Los Angeles, CA\nUnited States", "US"),
             ("Cabul, Afeganistão", "AF"),
-            ("Try to find South Sudan in a address", "SS"),
+            ("Try to find South Sudan in an address", "SS"),
             # The country code can be found using the capital name in any available language
             ("Kairo", "EG"),
             ("Paris", "FR"),


### PR DESCRIPTION
Avoid errors between Sudan "SD" and South Sudan "SS" in es and de