### PR TITLE
Papua New Guinea in special countries

### DIFF
--- a/geoconvert/data/countries.py
+++ b/geoconvert/data/countries.py
@@ -23,6 +23,8 @@ special_countries = {
     "sudan del sur": "SS", # es
     # Make sure we never mistake it for JE
     "new jersey": "US",
+    # Make sure we never mistake it for GN
+    "papua new guinea": "PG"
 }
 
 

--- a/test_geoconvert.py
+++ b/test_geoconvert.py
@@ -778,6 +778,8 @@ United States""",
             ("Try to find South Sudan in an address", "SS"),
             ("650 Great Rd, Princeton, New Jersey", "US"),
             ("St Peter, Jersey JE1 1BY, Jersey", "JE"),
+            ('East Asia and Pacific Region: Papua New Guinea', "PG"),
+            ('N1, Conakry, Guinea', "GN"),
             # The country code can be found using the capital name in any available language
             ("Kairo", "EG"),
             ("Paris", "FR"),


### PR DESCRIPTION
If no language had been selected, "de" is the default language where "guinea" exists (but not "papua new guinea"). 
It stops there because it found a match 
Same issue with sudan and new jersey
Papua New Guinea in special countries (PG not GN)