### PR TITLE
various detection improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - Do not mistake "océan indien" as IN
+- Support for Saint-Martin (France) postcodes
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Support for Python 3.12
 - Detection for DE and FR subdivisions using NUTS codes
+- escape ’ character as '
+
+### Fixed
+
+- Do not mistake "océan indien" as IN
 
 ### Dependencies
 

--- a/geoconvert/convert.py
+++ b/geoconvert/convert.py
@@ -281,6 +281,10 @@ def fr_postcode_to_dept_code(text):
             else:
                 return "20B"
 
+        # Saint-Martin
+        if postcode[:3] == "970":
+            return "971"
+
         # Other cases
         for code in (postcode[:2], postcode[:3]):
             if code in fr_departments.values():

--- a/geoconvert/data/countries.py
+++ b/geoconvert/data/countries.py
@@ -32,6 +32,10 @@ special_countries = {
     "south sudan": "SS",  # en
     "sudsudan": "SS",  # de
     "sudan del sur": "SS",  # es
+    # Make sure we never mistake "océan Indien" for IN
+    "territoire britannique de l'ocean indien": "IO",  # fr
+    "ocean indien": None,  # fr
+    "indien": "IN",  # de
     # Make sure we never mistake some countries or subdivisions for IS (Iceland)
     # We would mistake them because Iceland spells Island in German.
     "prince edward island": "CA",  # en
@@ -222,7 +226,6 @@ countries_fr = {
         "norvege": "NO",
         "nouvelle caledonie": "NC",
         "nouvelle zelande": "NZ",
-        "ocean indien": "IO",
         "oman": "OM",
         "ouganda": "UG",
         "ouzbekistan": "UZ",
@@ -651,7 +654,6 @@ countries_de = {
         "guyana": "GY",
         "haiti": "HT",
         "honduras": "HN",
-        "indien": "IN",
         "indonesien": "ID",
         "irak": "IQ",
         "iran": "IR",

--- a/geoconvert/utils.py
+++ b/geoconvert/utils.py
@@ -38,10 +38,14 @@ def safe_string(text):
     'washington dc'
     >>> safe_string('How aRE yOU?')
     'how are you'
+    >>> safe_string("l’ocean")
+    "l'ocean"
     """
     text = remove_accents(text)
     # Replace "-" and ":" with a whitespace
     text = re.sub(r"[-:]", " ", text)
+    # Replace weird '
+    text = re.sub(r"[ʼ]", "'", text)
     # Only keep word or space characters as well as "_", and "'".
     text = re.sub(r"[^\w\s']", "", text)
     # Always remove multiple whitespaces at the very last minute

--- a/tests/test_countries.py
+++ b/tests/test_countries.py
@@ -50,6 +50,11 @@ class TestCountries:
             ("sudan del sur", {}, "SS"),  # es
             ("Soudan du Sud", {}, "SS"),  # fr
             ("sudao do sul", {}, "SS"),  # pt
+            # No confusion between the indian ocean, the British Indian Ocean Territory
+            # and the deutsch name for india
+            ("indien", {}, "IN"),  # de
+            ("Territoire britannique de l’océan Indien", {}, "IO"),  # fr
+            ("Océan Indien", {}, None),  # fr
             # No confusion with Iceland, which spells "Island" in German ("IS")
             ("Cayman islands", {}, "KY"),  # en
             ("Christmas island", {}, "CX"),  # en

--- a/tests/test_subdivisions/test_france.py
+++ b/tests/test_subdivisions/test_france.py
@@ -172,6 +172,10 @@ class TestFrance:
             ("Rue de la Réunion, 75000 Paris", "75"),
             ("Rue de l'Orne, 44800 Saint-Herblain", "44"),
             ("D7, Sainte-Luce 97228, Martinique", "972"),
+            # Saint-Martin postcodes
+            ("Code postal 97150", "971"),
+            ("Code postal 97051", "971"),
+            ("Code postal 97080", "971"),
             ("99999", None),
         ],
     )


### PR DESCRIPTION
### Added

- escape ’ character as '

### Fixed

- Do not mistake "océan indien" as IN
- Support for Saint-Martin (France) postcodes