### PR TITLE
Use French region names when finding French subdivisions + bump to version 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Do not mistake "océan indien" as IN
 - Support for Saint-Martin (France) postcodes
+- Use French region names when finding French subdivisions
+  (the dept of the regional prefecture is used if a region name matched)
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## Unreleased
+## [5.2.0] - 2024-04-08
+
+- Use French region names when finding French subdivisions
+  (the dept of the regional prefecture is used if a region name matched)
+
+## [5.1.0] - 2024-02-27
 
 ### Added
 
@@ -15,8 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Do not mistake "océan indien" as IN
 - Support for Saint-Martin (France) postcodes
-- Use French region names when finding French subdivisions
-  (the dept of the regional prefecture is used if a region name matched)
 
 ### Dependencies
 

--- a/geoconvert/__init__.py
+++ b/geoconvert/__init__.py
@@ -1,2 +1,2 @@
 __author__ = "Octopusmind <informatique@octopusmind.info>"
-__version__ = "5.0.0"
+__version__ = "5.2.0"

--- a/geoconvert/convert.py
+++ b/geoconvert/convert.py
@@ -248,13 +248,14 @@ def us_postcode_to_state_code(text):
 
 def fr_address_to_dept_code(text):
     # First, look for NUTS code in the plain text
-    nuts_match = re.search(nuts_regexes_by_country["FR"], text)
-    if nuts_match:
+    if nuts_match := re.search(nuts_regexes_by_country["FR"], text):
         return NUTS_CODES_BY_COUNTRY["FR"].get(nuts_match.group().upper())
     # Look for the postcode and derive the dept code from it
-    code = fr_postcode_to_dept_code(text)
-    if code is not None:
+    if (code := fr_postcode_to_dept_code(text)) is not None:
         return code
+    # Look for the region name in plain text
+    if region_info := fr_region_name_to_info(text):
+        return region_info[0]
     # Look for the dept name in plain text
     return fr_dept_name_to_dept_code(text)
 

--- a/geoconvert/data/subdivisions/france.py
+++ b/geoconvert/data/subdivisions/france.py
@@ -19,7 +19,6 @@ fr_regions = {
     "auvergne": "83",  # old region (pre 2016)
     "bourgogne": "26",  # old region (pre 2016)
     "bretagne": "53",
-    "centre": "24",
     "champagne ardenne": "21",  # old region (pre 2016)
     "corse": "94",
     "franche comte": "43",  # old region (pre 2016)
@@ -41,6 +40,10 @@ fr_regions = {
     "provence alpes cote d'azur": "93",
     "reunion": "04",
     "rhone alpes": "82",  # old region (pre 2016)
+    # For the old region name "Centre", use longer names,
+    # to avoid false positives (especially for places such as "Centre Pompidou").
+    "region centre": "24",
+    "conseil regional centre": "24",
 }
 
 # Keep backward compatibility

--- a/tests/test_subdivisions/test_france.py
+++ b/tests/test_subdivisions/test_france.py
@@ -68,10 +68,10 @@ class TestFrance:
             ("M. le maire, hôtel de Ville 97717 Saint-Denis", "974"),
             ("Rue de la Réunion, 75000 Paris", "75"),
             ("Rue de l'Orne, 44800 Saint-Herblain", "44"),
-            # nuts code
+            # NUTS code
             ("stasticial region FRB04", "37"),
             ("stasticial region fr244", "37"),
-            # dept names
+            # Dept names
             ("Martinique", "972"),
             ("cotes d'armr", None),
             ("cotes d'armor", "22"),
@@ -105,6 +105,18 @@ class TestFrance:
             ("Tout savoir sur Saint Barthélemy", "977"),
             ("Tout savoir sur saint-barthelemy", "977"),
             ("Tout savoir sur saint Barthélémy", "977"),
+            # Region names
+            ("Pays de la Loire", "44"),
+            # Special cases for the old French région "Centre"
+            ("Région Centre", "45"),
+            ("Conseil Régional centre", "45"),
+            # No confusion with the old "Centre" name for the French region "Centre-Val-de-Loire"
+            ("Centre Pompidou", None),
+            # No confusion with the "Nord" department
+            ("Hopital nord Franche Comté", "25"),
+            # Both dept name and region name
+            ("Guyane", "973"),
+            ("Guadeloupe", "971"),
             # There can be some mistakes, that we may want to fix one day.
             # In this case, we could look for 2 or 3 digit
             ("Rue de l'Orne, Saint-Herblain (44)", "61"),

--- a/tests/test_subdivisions/test_subdivisions_without_countries.py
+++ b/tests/test_subdivisions/test_subdivisions_without_countries.py
@@ -51,6 +51,8 @@ class TestNoCountryProvided:
             # No mistakes with Iceland (IS)
             ("Prince Edward Island", {}, "PE"),
             ("Rhode Island", {}, "RI"),
+            # No confusion with the old French région Centre
+            ("London Centre for Nanotechnology", {}, None),
             #
             # Detection with nuts code.
             #


### PR DESCRIPTION
- **Bump version to 5.2.0**
- **Use French region names when finding French subdivisions**

  If a French region name is found for a text related to the France country, then the department of the regional prefecture is returned as the matching subdivision.
    
  This works with old (pre-2016) and new (post-2016) region names, with a special case for the old region name "Centre", which is not used to avoid false postives (with, e.g., "Centre Pompidou"). To match this old region name, there must be "region centre" or "conseil regional centre" in the input text.