### PR TITLE
find_countries no longer look for countries codes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## Rolling
+
+### Fixed
+
+- find_countries no longer look for countries codes by default
+
 ## [6.0.0] - 2026-04-07
 
 ### Added

--- a/geoconvert/convert.py
+++ b/geoconvert/convert.py
@@ -834,12 +834,18 @@ def _guess_subdivision_then_country_codes(text):
     return (None, None)
 
 
-def find_countries(text, lang=None):
+def find_countries(text, lang=None, enable_ambiguous_detection=False):
     """
     Detect countries from a given text.
+
+    If the given text is known to contain only countries data,
+    set enable_ambiguous_detection=True to improve the detection by enabling country detection using country codes.
+
     >>> find_countries('In france and trinidad y tobago')
     ['FR', 'TT']
     >>> find_countries('FR In Gabon and Germany, CH')
+    ['DE', 'GA']
+    >>> find_countries('FR In Gabon and Germany, CH', enable_ambiguous_detection=True)
     ['CH', 'DE', 'FR', 'GA']
     """
 
@@ -859,9 +865,10 @@ def find_countries(text, lang=None):
         safe_text = safe_text.replace(country[0], "")
 
     # Find countries from country codes
-    safe_text = re.sub(r"[^A-Z\s]", " ", text)
-    for sub_text in safe_text.split():
-        if len(sub_text) == 2 and sub_text in ALL_COUNTRY_CODES:
-            countries.add(sub_text)
+    if enable_ambiguous_detection:
+        two_letter_codes = re.findall(r"\b([A-Z]{2})\b", text)
+        for two_letter_code in two_letter_codes:
+            if two_letter_code in ALL_COUNTRY_CODES:
+                countries.add(two_letter_code)
 
     return sorted(list(countries))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -7,15 +7,6 @@ class TestConvert:
     @pytest.mark.parametrize(
         "input_data, expected",
         [
-            # As codes
-            (
-                "AT,KO,NO",
-                ["AT", "KO", "NO"],
-            ),
-            (  # non valids codes are not taken
-                "AT,KO,NO,XX",
-                ["AT", "KO", "NO"],
-            ),
             # only one word
             (
                 "spain",
@@ -81,6 +72,62 @@ class TestConvert:
         Test countries detection
         """
         result = find_countries(input_data)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "input_data, expected",
+        [
+            # Codes are not detected if not safe
+            (
+                "AT,KO,NO",
+                [],
+            ),
+            (
+                "AT,KO,NO,XX",
+                [],
+            ),
+            # Avoid taking non-country codes as country codes
+            ("TEST NO 3", []),
+            ("TO DO", []),
+            ("AN OBJECT", []),
+            # not a country code anyway
+            ("TeST", []),
+        ],
+    )
+    def test_find_countries_with_codes_safe_detection(self, input_data, expected):
+        """
+        Test countries detection with codes.
+        Without the "enable_ambiguous_detection" flag, codes are not detected.
+        """
+        result = find_countries(input_data, enable_ambiguous_detection=False)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "input_data, expected",
+        [
+            # Codes
+            (
+                "AT,KO,NO",
+                ["AT", "KO", "NO"],
+            ),
+            (  # non-valid codes are not taken
+                "AT,KO,NO,XX",
+                ["AT", "KO", "NO"],
+            ),
+            # Risk of taking non-country codes as country codes
+            ("TEST NO 3", ["NO"]),
+            ("TO DO", ["DO", "TO"]),
+            ("AN OBJECT", ["AN"]),
+            # not a country code anyway
+            ("TeST", []),
+        ],
+    )
+    def test_find_countries_with_codes_ambiguous_detection(self, input_data, expected):
+        """
+        Test countries detection with codes.
+        With the "enable_ambiguous_detection" flag, codes are detected.
+        """
+        result = find_countries(input_data, enable_ambiguous_detection=True)
         assert result == expected
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
- add a "safe" flag on `find_countries` to enable or disable country detection by code
- improve country detection by code by looking only for two-letters upper case words